### PR TITLE
ci: add Rust workflow (build + test) identical to mosaic-core

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blake3"
@@ -205,12 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "bytemuck"
-version = "1.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,10 +212,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -457,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
 ]
@@ -548,14 +543,14 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.9.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
+checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.3",
+ "libm",
  "rand",
  "siphasher",
- "wide",
 ]
 
 [[package]]
@@ -573,6 +568,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flume"
@@ -724,7 +725,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -896,9 +897,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -915,6 +916,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "litrs"
@@ -934,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -1037,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.6.99"
-source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#c623df264debeaf75cb043d518048748e09de29c"
+source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#8292491c6a5458fcb3e1192ef4ff9922f83b00a3"
 dependencies = [
  "bitflags",
  "blake3",
@@ -1060,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "mosaic-net"
 version = "0.3.0"
-source = "git+https://github.com/mikedilger/mosaic-net?branch=master#6cc1ccfc1f79554e2b1e766e917ac2a962ba1865"
+source = "git+https://github.com/mikedilger/mosaic-net?branch=master#c89bce127dd091f37f299b8ea1a2d7c1f8530362"
 dependencies = [
  "alt-tls",
  "mosaic-core",
@@ -1329,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1340,7 +1347,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1349,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -1372,16 +1379,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1515,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
@@ -1552,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -1567,7 +1574,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 0.26.11",
+ "webpki-root-certs",
  "windows-sys 0.59.0",
 ]
 
@@ -1579,9 +1586,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1593,15 +1600,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "salsa20"
@@ -1623,11 +1621,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1664,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1677,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1687,16 +1685,17 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1712,18 +1711,28 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1789,16 +1798,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -1899,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -1914,15 +1913,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1958,7 +1957,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -2014,9 +2013,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "universal-hash"
@@ -2058,30 +2057,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -2093,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2103,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2116,18 +2125,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2145,15 +2154,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
@@ -2162,22 +2162,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
-
-[[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2185,6 +2175,12 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -2220,6 +2216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2259,7 +2264,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2409,13 +2414,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "x25519-dalek"
@@ -2463,18 +2465,18 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "minicbor"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f182275033b808ede9427884caa8e05fa7db930801759524ca7925bd8aa7a82"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17290c95158a760027059fe3f511970d6857e47ff5008f9e09bffe3d3e1c6af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546cc904f35809921fa57016a84c97e68d9d27c012e87b9dadc28c233705f783"
+dependencies = [
+ "minicbor",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,8 +1036,8 @@ dependencies = [
 
 [[package]]
 name = "mosaic-core"
-version = "0.4.14"
-source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#e83ca409f53aebcf4733ea69cd113e7de46475b5"
+version = "0.6.99"
+source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#c623df264debeaf75cb043d518048748e09de29c"
 dependencies = [
  "bitflags",
  "blake3",
@@ -1019,6 +1049,9 @@ dependencies = [
  "http",
  "instant",
  "mainline",
+ "minicbor",
+ "minicbor-derive",
+ "minicbor-serde",
  "rand",
  "scrypt",
  "z32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,6 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.4.14"
-source = "git+https://github.com/mikedilger/mosaic-core?branch=master#76e0d2edf3d0766b3c839914a5fb9c76dfe7d3ca"
 dependencies = [
  "bitflags",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.4.14"
+source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#e83ca409f53aebcf4733ea69cd113e7de46475b5"
 dependencies = [
  "bitflags",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ tokio = { version = "1", features = [ "full" ] }
 
 [dev-dependencies]
 quinn = "0.11"
+[patch."https://github.com/mikedilger/mosaic-core"]
+mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ tokio = { version = "1", features = [ "full" ] }
 [dev-dependencies]
 quinn = "0.11"
 [patch."https://github.com/mikedilger/mosaic-core"]
+# Point CI to the PR branch of mosaic-core
 mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-1" }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -43,10 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(message) = channel.recv().await? {
         match message.message_type() {
             MessageType::SubmissionResult => {
-                eprintln!(
-                    "Submission result: {:?}",
-                    message.submission_result_code().unwrap()
-                );
+                eprintln!("Submission result: {:?}", message.result_code().unwrap());
             }
             mt => {
                 eprintln!("Unexpected response: {mt:?}={message:?}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,11 @@
 use std::net::SocketAddr;
 
-use mosaic_core::PublicKey;
+use mosaic_core::{PublicKey, ResultCode};
 
 pub struct ClientData {
     pub remote_address: SocketAddr,
     pub peer: Option<PublicKey>,
     pub mosaic_version: Option<u16>,
     pub applications: Option<Vec<u32>>,
+    pub closing_result: Option<ResultCode>,
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,62 +1,227 @@
-use mosaic_core::{HelloErrorCode, Message, MessageType};
+use mosaic_core::{HelloErrorCode, Message, MessageType, ResultCode};
 
 use crate::Error;
 use crate::client::ClientData;
+
+const SUPPORTED_MAJOR_VERSION: u16 = 0;
 
 pub(crate) async fn handle_mosaic_message(
     message: Message,
     client_data: &mut ClientData,
 ) -> Result<Option<Message>, Error> {
-
     match message.message_type() {
-        MessageType::Hello => {
-            // We can ignore their major version, the best we can support is 0
-            let version: u16 = 0;
-            client_data.mosaic_version = Some(version);
-
-            // These are the apps they are requesting. We can only support 0
-            // (which maybe doesn't need to be specified, but if they did, we do).
-            let req_app_ids = message.application_ids().unwrap();
-            let apps: Vec<u32> = if req_app_ids.contains(&0) {
-                vec![0]
-            } else {
-                vec![]
-            };
-            client_data.applications = Some(apps.clone());
-
-            let code = if client_data.mosaic_version.is_some() {
-                HelloErrorCode::UnexpectedHello
-            } else {
-                HelloErrorCode::NoError
-            };
-
-            Ok(Some(Message::new_hello_ack(
-                code,
-                version,
-                &apps,
-            )?))
-        },
+        MessageType::Hello => handle_hello(message, client_data),
         MessageType::Get => {
             todo!()
-        },
+        }
         MessageType::Query => {
             todo!()
-        },
+        }
         MessageType::Subscribe => {
             todo!()
-        },
+        }
         MessageType::Unsubscribe => {
             todo!()
-        },
+        }
         MessageType::Submission => {
             todo!()
-        },
-        MessageType::Unrecognized => {
-            Ok(Some(Message::new_unrecognized()))
         }
-        _ => {
-            Ok(Some(Message::new_unrecognized()))
+        MessageType::Unrecognized => Ok(Some(Message::new_unrecognized())),
+        _ => Ok(Some(Message::new_unrecognized())),
+    }
+}
+
+fn handle_hello(message: Message, client_data: &mut ClientData) -> Result<Option<Message>, Error> {
+    if client_data.mosaic_version.is_some() {
+        let prior_apps = client_data.applications.clone().unwrap_or_default();
+        client_data.closing_result = Some(ResultCode::Invalid);
+
+        let ack = Message::new_hello_ack(
+            HelloErrorCode::UnexpectedHello,
+            SUPPORTED_MAJOR_VERSION,
+            &prior_apps,
+        )?;
+
+        return Ok(Some(ack));
+    }
+
+    let client_version = match message.mosaic_major_version() {
+        Some(v) => v,
+        None => {
+            client_data.closing_result = Some(ResultCode::Invalid);
+            let ack = Message::new_hello_ack(
+                HelloErrorCode::UnexpectedHello,
+                SUPPORTED_MAJOR_VERSION,
+                &[],
+            )?;
+            return Ok(Some(ack));
+        }
+    };
+
+    if client_version != SUPPORTED_MAJOR_VERSION {
+        client_data.closing_result = Some(ResultCode::Invalid);
+        let ack = Message::new_hello_ack(
+            HelloErrorCode::IncompatibleMajorVersion,
+            SUPPORTED_MAJOR_VERSION,
+            &[],
+        )?;
+        return Ok(Some(ack));
+    }
+
+    let frame_len = message.len();
+    if frame_len < 8 || ((frame_len - 8) % 4) != 0 {
+        client_data.closing_result = Some(ResultCode::Invalid);
+        let ack = Message::new_hello_ack(
+            HelloErrorCode::UnexpectedHello,
+            SUPPORTED_MAJOR_VERSION,
+            &[],
+        )?;
+        return Ok(Some(ack));
+    }
+
+    let requested_apps = match message.application_ids() {
+        Some(apps) => apps,
+        None => {
+            client_data.closing_result = Some(ResultCode::Invalid);
+            let ack = Message::new_hello_ack(
+                HelloErrorCode::UnexpectedHello,
+                SUPPORTED_MAJOR_VERSION,
+                &[],
+            )?;
+            return Ok(Some(ack));
+        }
+    };
+
+    let mut accepted_apps: Vec<u32> = requested_apps.into_iter().filter(|app| *app == 0).collect();
+
+    if accepted_apps.is_empty() {
+        accepted_apps.shrink_to_fit();
+    }
+
+    let ack = Message::new_hello_ack(
+        HelloErrorCode::NoError,
+        SUPPORTED_MAJOR_VERSION,
+        &accepted_apps,
+    )?;
+
+    client_data.mosaic_version = Some(SUPPORTED_MAJOR_VERSION);
+    client_data.applications = Some(accepted_apps);
+    client_data.closing_result = None;
+
+    Ok(Some(ack))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_client() -> ClientData {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        ClientData {
+            remote_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            peer: None,
+            mosaic_version: None,
+            applications: None,
+            closing_result: None,
         }
     }
 
+    #[tokio::test]
+    async fn hello_success() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[0]).unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(response.hello_error_code(), Some(HelloErrorCode::NoError));
+        assert_eq!(client.mosaic_version, Some(SUPPORTED_MAJOR_VERSION));
+        assert_eq!(client.applications, Some(vec![0]));
+        assert!(client.closing_result.is_none());
+    }
+
+    #[tokio::test]
+    async fn hello_repeated_returns_unexpected() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[0]).unwrap();
+
+        let _ = handle_mosaic_message(hello.clone(), &mut client)
+            .await
+            .unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(
+            response.hello_error_code(),
+            Some(HelloErrorCode::UnexpectedHello)
+        );
+        assert_eq!(client.closing_result, Some(ResultCode::Invalid));
+    }
+
+    #[tokio::test]
+    async fn hello_incompatible_version_requests_close() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION + 1, &[0]).unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(
+            response.hello_error_code(),
+            Some(HelloErrorCode::IncompatibleMajorVersion)
+        );
+        assert_eq!(client.closing_result, Some(ResultCode::Invalid));
+        assert_eq!(client.mosaic_version, None);
+    }
+
+    #[tokio::test]
+    async fn hello_with_malformed_length_requests_close() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[0]).unwrap();
+        let mut bytes = hello.as_bytes().to_vec();
+        // Corrupt the advertised length so it is no longer a multiple of 4 bytes.
+        bytes[1] = 9;
+        let malformed = unsafe { Message::from_bytes_unchecked(bytes) };
+
+        let response = handle_mosaic_message(malformed, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(
+            response.hello_error_code(),
+            Some(HelloErrorCode::UnexpectedHello)
+        );
+        assert_eq!(client.closing_result, Some(ResultCode::Invalid));
+        assert_eq!(client.mosaic_version, None);
+        assert!(client.applications.is_none());
+    }
+
+    #[tokio::test]
+    async fn hello_without_app_zero_acknowledges_none() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[]).unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(response.hello_error_code(), Some(HelloErrorCode::NoError));
+        assert_eq!(client.applications, Some(Vec::new()));
+        assert!(client.closing_result.is_none());
+    }
 }


### PR DESCRIPTION
Adds .github/workflows/rust.yml matching mosaic-core to run cargo build and cargo test on pushes to master and pull requests targeting master. This enables CI on PRs.