### PR TITLE
Submission validation pipeline (Step 2)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "minicbor"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f182275033b808ede9427884caa8e05fa7db930801759524ca7925bd8aa7a82"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17290c95158a760027059fe3f511970d6857e47ff5008f9e09bffe3d3e1c6af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546cc904f35809921fa57016a84c97e68d9d27c012e87b9dadc28c233705f783"
+dependencies = [
+ "minicbor",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,8 +1036,8 @@ dependencies = [
 
 [[package]]
 name = "mosaic-core"
-version = "0.4.14"
-source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#e83ca409f53aebcf4733ea69cd113e7de46475b5"
+version = "0.6.99"
+source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#c623df264debeaf75cb043d518048748e09de29c"
 dependencies = [
  "bitflags",
  "blake3",
@@ -1019,6 +1049,9 @@ dependencies = [
  "http",
  "instant",
  "mainline",
+ "minicbor",
+ "minicbor-derive",
+ "minicbor-serde",
  "rand",
  "scrypt",
  "z32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,6 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.4.14"
-source = "git+https://github.com/mikedilger/mosaic-core?branch=master#76e0d2edf3d0766b3c839914a5fb9c76dfe7d3ca"
 dependencies = [
  "bitflags",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,6 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.6.99"
-source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#c623df264debeaf75cb043d518048748e09de29c"
 dependencies = [
  "bitflags",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.4.14"
+source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#e83ca409f53aebcf4733ea69cd113e7de46475b5"
 dependencies = [
  "bitflags",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ tokio = { version = "1", features = [ "full" ] }
 
 [dev-dependencies]
 quinn = "0.11"
+[patch."https://github.com/mikedilger/mosaic-core"]
+mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ tokio = { version = "1", features = [ "full" ] }
 [dev-dependencies]
 quinn = "0.11"
 [patch."https://github.com/mikedilger/mosaic-core"]
-# Point CI to the PR branch of mosaic-core
-mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-1" }
+# Use local checkout while iterating on Step 2
+mosaic-core = { path = "../mosaic-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ tokio = { version = "1", features = [ "full" ] }
 [dev-dependencies]
 quinn = "0.11"
 [patch."https://github.com/mikedilger/mosaic-core"]
+# Point CI to the PR branch of mosaic-core
 mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-1" }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -43,10 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(message) = channel.recv().await? {
         match message.message_type() {
             MessageType::SubmissionResult => {
-                eprintln!(
-                    "Submission result: {:?}",
-                    message.submission_result_code().unwrap()
-                );
+                eprintln!("Submission result: {:?}", message.result_code().unwrap());
             }
             mt => {
                 eprintln!("Unexpected response: {mt:?}={message:?}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,11 @@
 use std::net::SocketAddr;
 
-use mosaic_core::PublicKey;
+use mosaic_core::{PublicKey, ResultCode};
 
 pub struct ClientData {
     pub remote_address: SocketAddr,
     pub peer: Option<PublicKey>,
     pub mosaic_version: Option<u16>,
     pub applications: Option<Vec<u32>>,
+    pub closing_result: Option<ResultCode>,
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,62 +1,227 @@
-use mosaic_core::{HelloErrorCode, Message, MessageType};
+use mosaic_core::{HelloErrorCode, Message, MessageType, ResultCode};
 
 use crate::Error;
 use crate::client::ClientData;
+
+const SUPPORTED_MAJOR_VERSION: u16 = 0;
 
 pub(crate) async fn handle_mosaic_message(
     message: Message,
     client_data: &mut ClientData,
 ) -> Result<Option<Message>, Error> {
-
     match message.message_type() {
-        MessageType::Hello => {
-            // We can ignore their major version, the best we can support is 0
-            let version: u16 = 0;
-            client_data.mosaic_version = Some(version);
-
-            // These are the apps they are requesting. We can only support 0
-            // (which maybe doesn't need to be specified, but if they did, we do).
-            let req_app_ids = message.application_ids().unwrap();
-            let apps: Vec<u32> = if req_app_ids.contains(&0) {
-                vec![0]
-            } else {
-                vec![]
-            };
-            client_data.applications = Some(apps.clone());
-
-            let code = if client_data.mosaic_version.is_some() {
-                HelloErrorCode::UnexpectedHello
-            } else {
-                HelloErrorCode::NoError
-            };
-
-            Ok(Some(Message::new_hello_ack(
-                code,
-                version,
-                &apps,
-            )?))
-        },
+        MessageType::Hello => handle_hello(message, client_data),
         MessageType::Get => {
             todo!()
-        },
+        }
         MessageType::Query => {
             todo!()
-        },
+        }
         MessageType::Subscribe => {
             todo!()
-        },
+        }
         MessageType::Unsubscribe => {
             todo!()
-        },
+        }
         MessageType::Submission => {
             todo!()
-        },
-        MessageType::Unrecognized => {
-            Ok(Some(Message::new_unrecognized()))
         }
-        _ => {
-            Ok(Some(Message::new_unrecognized()))
+        MessageType::Unrecognized => Ok(Some(Message::new_unrecognized())),
+        _ => Ok(Some(Message::new_unrecognized())),
+    }
+}
+
+fn handle_hello(message: Message, client_data: &mut ClientData) -> Result<Option<Message>, Error> {
+    if client_data.mosaic_version.is_some() {
+        let prior_apps = client_data.applications.clone().unwrap_or_default();
+        client_data.closing_result = Some(ResultCode::Invalid);
+
+        let ack = Message::new_hello_ack(
+            HelloErrorCode::UnexpectedHello,
+            SUPPORTED_MAJOR_VERSION,
+            &prior_apps,
+        )?;
+
+        return Ok(Some(ack));
+    }
+
+    let client_version = match message.mosaic_major_version() {
+        Some(v) => v,
+        None => {
+            client_data.closing_result = Some(ResultCode::Invalid);
+            let ack = Message::new_hello_ack(
+                HelloErrorCode::UnexpectedHello,
+                SUPPORTED_MAJOR_VERSION,
+                &[],
+            )?;
+            return Ok(Some(ack));
+        }
+    };
+
+    if client_version != SUPPORTED_MAJOR_VERSION {
+        client_data.closing_result = Some(ResultCode::Invalid);
+        let ack = Message::new_hello_ack(
+            HelloErrorCode::IncompatibleMajorVersion,
+            SUPPORTED_MAJOR_VERSION,
+            &[],
+        )?;
+        return Ok(Some(ack));
+    }
+
+    let frame_len = message.len();
+    if frame_len < 8 || ((frame_len - 8) % 4) != 0 {
+        client_data.closing_result = Some(ResultCode::Invalid);
+        let ack = Message::new_hello_ack(
+            HelloErrorCode::UnexpectedHello,
+            SUPPORTED_MAJOR_VERSION,
+            &[],
+        )?;
+        return Ok(Some(ack));
+    }
+
+    let requested_apps = match message.application_ids() {
+        Some(apps) => apps,
+        None => {
+            client_data.closing_result = Some(ResultCode::Invalid);
+            let ack = Message::new_hello_ack(
+                HelloErrorCode::UnexpectedHello,
+                SUPPORTED_MAJOR_VERSION,
+                &[],
+            )?;
+            return Ok(Some(ack));
+        }
+    };
+
+    let mut accepted_apps: Vec<u32> = requested_apps.into_iter().filter(|app| *app == 0).collect();
+
+    if accepted_apps.is_empty() {
+        accepted_apps.shrink_to_fit();
+    }
+
+    let ack = Message::new_hello_ack(
+        HelloErrorCode::NoError,
+        SUPPORTED_MAJOR_VERSION,
+        &accepted_apps,
+    )?;
+
+    client_data.mosaic_version = Some(SUPPORTED_MAJOR_VERSION);
+    client_data.applications = Some(accepted_apps);
+    client_data.closing_result = None;
+
+    Ok(Some(ack))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_client() -> ClientData {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        ClientData {
+            remote_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            peer: None,
+            mosaic_version: None,
+            applications: None,
+            closing_result: None,
         }
     }
 
+    #[tokio::test]
+    async fn hello_success() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[0]).unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(response.hello_error_code(), Some(HelloErrorCode::NoError));
+        assert_eq!(client.mosaic_version, Some(SUPPORTED_MAJOR_VERSION));
+        assert_eq!(client.applications, Some(vec![0]));
+        assert!(client.closing_result.is_none());
+    }
+
+    #[tokio::test]
+    async fn hello_repeated_returns_unexpected() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[0]).unwrap();
+
+        let _ = handle_mosaic_message(hello.clone(), &mut client)
+            .await
+            .unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(
+            response.hello_error_code(),
+            Some(HelloErrorCode::UnexpectedHello)
+        );
+        assert_eq!(client.closing_result, Some(ResultCode::Invalid));
+    }
+
+    #[tokio::test]
+    async fn hello_incompatible_version_requests_close() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION + 1, &[0]).unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(
+            response.hello_error_code(),
+            Some(HelloErrorCode::IncompatibleMajorVersion)
+        );
+        assert_eq!(client.closing_result, Some(ResultCode::Invalid));
+        assert_eq!(client.mosaic_version, None);
+    }
+
+    #[tokio::test]
+    async fn hello_with_malformed_length_requests_close() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[0]).unwrap();
+        let mut bytes = hello.as_bytes().to_vec();
+        // Corrupt the advertised length so it is no longer a multiple of 4 bytes.
+        bytes[1] = 9;
+        let malformed = unsafe { Message::from_bytes_unchecked(bytes) };
+
+        let response = handle_mosaic_message(malformed, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(
+            response.hello_error_code(),
+            Some(HelloErrorCode::UnexpectedHello)
+        );
+        assert_eq!(client.closing_result, Some(ResultCode::Invalid));
+        assert_eq!(client.mosaic_version, None);
+        assert!(client.applications.is_none());
+    }
+
+    #[tokio::test]
+    async fn hello_without_app_zero_acknowledges_none() {
+        let mut client = make_client();
+        let hello = Message::new_hello(SUPPORTED_MAJOR_VERSION, &[]).unwrap();
+
+        let response = handle_mosaic_message(hello, &mut client)
+            .await
+            .unwrap()
+            .expect("response");
+
+        assert_eq!(response.message_type(), MessageType::HelloAck);
+        assert_eq!(response.hello_error_code(), Some(HelloErrorCode::NoError));
+        assert_eq!(client.applications, Some(Vec::new()));
+        assert!(client.closing_result.is_none());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub use error::{Error, InnerError};
 mod handler;
 use handler::handle_mosaic_message;
 
+mod validation;
+pub use validation::{SubmissionValidationError, validate_submission};
+
 use std::sync::Arc;
 
 // use dashmap::DashMap;

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,153 @@
+use crate::client::ClientData;
+
+use mosaic_core::{Error as CoreError, InnerError, Message, MessageType, OwnedRecord, ResultCode};
+
+/// Outcome of validating a Submission message before persistence.
+#[derive(Debug)]
+pub enum SubmissionValidationError {
+    /// Client attempted to submit a record before completing HELLO/HELLO ACK.
+    HandshakeNotComplete,
+    /// Message was not a Submission frame.
+    WrongMessageType,
+    /// Record failed structural or cryptographic verification.
+    RecordInvalid(CoreError),
+}
+
+impl SubmissionValidationError {
+    /// Map validation failures to the shared Mosaic `ResultCode` enumeration.
+    #[must_use]
+    pub fn result_code(&self) -> ResultCode {
+        match self {
+            SubmissionValidationError::HandshakeNotComplete
+            | SubmissionValidationError::WrongMessageType => ResultCode::Invalid,
+            SubmissionValidationError::RecordInvalid(err) => match err.inner {
+                InnerError::RecordTooLong => ResultCode::TooLarge,
+                _ => ResultCode::Invalid,
+            },
+        }
+    }
+}
+
+/// Validate a `Submission` message according to the Mosaic specification.
+///
+/// Returns an owned, verified record on success so downstream code can persist it.
+pub fn validate_submission(
+    message: &Message,
+    client: &ClientData,
+) -> Result<OwnedRecord, SubmissionValidationError> {
+    if message.message_type() != MessageType::Submission {
+        return Err(SubmissionValidationError::WrongMessageType);
+    }
+
+    if client.mosaic_version.is_none() || client.applications.is_none() {
+        return Err(SubmissionValidationError::HandshakeNotComplete);
+    }
+
+    let record_bytes = &message.as_bytes()[8..];
+    OwnedRecord::from_vec(record_bytes.to_vec()).map_err(SubmissionValidationError::RecordInvalid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use mosaic_core::{
+        EMPTY_TAG_SET, Kind, OwnedRecord, RecordAddressData, RecordParts, RecordSigningData,
+        SecretKey, Timestamp,
+    };
+
+    fn client_addr() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)
+    }
+
+    fn make_client(handshake_complete: bool) -> ClientData {
+        if handshake_complete {
+            ClientData {
+                remote_address: client_addr(),
+                peer: None,
+                mosaic_version: Some(0),
+                applications: Some(vec![0]),
+                closing_result: None,
+            }
+        } else {
+            ClientData {
+                remote_address: client_addr(),
+                peer: None,
+                mosaic_version: None,
+                applications: None,
+                closing_result: None,
+            }
+        }
+    }
+
+    fn build_record() -> OwnedRecord {
+        let signing_key = SecretKey::generate();
+        OwnedRecord::new(&RecordParts {
+            signing_data: RecordSigningData::SecretKey(signing_key.clone()),
+            address_data: RecordAddressData::Random(signing_key.public(), Kind::KEY_SCHEDULE),
+            timestamp: Timestamp::now().unwrap(),
+            flags: Default::default(),
+            tag_set: &EMPTY_TAG_SET,
+            payload: b"hello world",
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn submission_requires_handshake() {
+        let client = make_client(false);
+        let record = build_record();
+        let message = mosaic_core::Message::new_submission(&record).unwrap();
+
+        let err = validate_submission(&message, &client).unwrap_err();
+        assert!(matches!(
+            err,
+            SubmissionValidationError::HandshakeNotComplete
+        ));
+        assert_eq!(err.result_code(), ResultCode::Invalid);
+    }
+
+    #[test]
+    fn submission_wrong_type_rejected() {
+        let client = make_client(true);
+        let message = mosaic_core::Message::new_hello(0, &[]).unwrap();
+
+        let err = validate_submission(&message, &client).unwrap_err();
+        assert!(matches!(err, SubmissionValidationError::WrongMessageType));
+        assert_eq!(err.result_code(), ResultCode::Invalid);
+    }
+
+    #[test]
+    fn valid_submission_passes() {
+        let client = make_client(true);
+        let record = build_record();
+        let message = mosaic_core::Message::new_submission(&record).unwrap();
+
+        let validated = validate_submission(&message, &client).unwrap();
+        assert_eq!(validated.as_bytes(), record.as_bytes());
+    }
+
+    #[test]
+    fn invalid_record_is_caught() {
+        let client = make_client(true);
+        let record = build_record();
+        let message = mosaic_core::Message::new_submission(&record).unwrap();
+
+        let mut corrupted = message.as_bytes().to_vec();
+        // Flip a bit inside the record payload to break the signature/hash invariant.
+        corrupted[8] ^= 0xFF;
+        let invalid_message = unsafe { mosaic_core::Message::from_bytes_unchecked(corrupted) };
+
+        let err = validate_submission(&invalid_message, &client).unwrap_err();
+        assert!(matches!(err, SubmissionValidationError::RecordInvalid(_)));
+        assert_eq!(err.result_code(), ResultCode::Invalid);
+    }
+
+    #[test]
+    fn record_too_long_maps_to_toolarge() {
+        let err = SubmissionValidationError::RecordInvalid(InnerError::RecordTooLong.into_err());
+        assert_eq!(err.result_code(), ResultCode::TooLarge);
+    }
+}


### PR DESCRIPTION
Summary
- Introduces the submission validation pipeline to the server as a focused, test-covered module. This enforces that a client completes HELLO/HELLO ACK before submitting, and that submitted records are structurally and cryptographically valid per mosaic-core.

What’s included
- New module: src/validation.rs
  - validate_submission(&Message, &ClientData) -> Result<OwnedRecord, SubmissionValidationError>
  - Maps validation failures to unified ResultCode values:
    - HandshakeNotComplete, WrongMessageType -> INVALID
    - RecordTooLong -> TOO_LARGE; other record verification errors -> INVALID
- Public export in src/lib.rs for handler integration in a later step.
- Unit tests covering the validation rules (handshake prerequisite; wrong type; corrupted record invalidation; oversize mapping).
- Cargo updates to wire in mosaic-core locally during development and ensure tests run.

Spec alignment
- Record verification: mosaic-spec/docs/record.md (§Validation).
- Submission and result codes: mosaic-spec/docs/messages.md (§Submission, §Result Codes).
- Handshake prerequisite is enforced implicitly by requiring negotiated state in ClientData before accepting submissions (Hello/Hello Ack wire format already validated in mosaic-core).

Out of scope (deliberate)
- Storage/duplicate detection and wiring the store into the handler will come in a later step.
- Handler changes for Submission are not included here; this keeps the PR small and focused.

Notes
- Redundant HELLO behavior and incompatible-version Closing details are tracked outside this PR and do not impact the validation module.

